### PR TITLE
Pin yum dependent cookbooks

### DIFF
--- a/tools/chef/nodes/development.local.json
+++ b/tools/chef/nodes/development.local.json
@@ -15,7 +15,11 @@
     "sites": {
       "{{hostname}}": {
         "docroot": "/vagrant/public",
-        "endpoint": "app_dev.php"
+        "endpoint": "app_dev.php",
+        "php-fpm": {
+          "host": "127.0.0.1",
+          "port": "9000"
+        }
       }
     },
     "fastcgi_buffers": "8 16k",


### PR DESCRIPTION
Attempts to get a quick Symfony installation via hobo-inviqa lead down a rabbit hole of cookbook dependencies.

This is an attempt to solve them by pinning the cookbook versions to ones that were before yum 3.0 requirements
